### PR TITLE
Fix workflow permissions for code scanning alert

### DIFF
--- a/.github/workflows/azure-static-web-apps-ashy-desert-0af533b10.yml
+++ b/.github/workflows/azure-static-web-apps-ashy-desert-0af533b10.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/azure-static-web-apps-ashy-sea-0c4757f10.yml
+++ b/.github/workflows/azure-static-web-apps-ashy-sea-0c4757f10.yml
@@ -14,6 +14,9 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Fixes #1

Add necessary permissions to GitHub workflows to fix code scanning alert.

* **.github/workflows/azure-static-web-apps-ashy-sea-0c4757f10.yml**
  - Add `permissions` field under `build_and_deploy_job` with `id-token: write` and `contents: read`.

* **.github/workflows/azure-static-web-apps-ashy-desert-0af533b10.yml**
  - Add `security-events: write` to `permissions` field under `build_and_deploy_job`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/acevedod1974/Lechugas/pull/2?shareId=25742184-4931-4522-a345-784d88a3f821).