### PR TITLE
Fix code scanning alert - Workflow does not contain permissions

### DIFF
--- a/.github/workflows/azure-static-web-apps-ashy-desert-0af533b10.yml
+++ b/.github/workflows/azure-static-web-apps-ashy-desert-0af533b10.yml
@@ -18,6 +18,7 @@ jobs:
       id-token: write
       contents: read
       security-events: write
+      actions: read
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/azure-static-web-apps-ashy-sea-0c4757f10.yml
+++ b/.github/workflows/azure-static-web-apps-ashy-sea-0c4757f10.yml
@@ -18,6 +18,7 @@ jobs:
       id-token: write
       contents: read
       security-events: write
+      actions: read
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Fixes #5

Add necessary permissions to workflow files to fix code scanning alert.

* Update `.github/workflows/azure-static-web-apps-ashy-desert-0af533b10.yml` to include `actions: read` permission under the `permissions` section.
* Update `.github/workflows/azure-static-web-apps-ashy-sea-0c4757f10.yml` to include `actions: read` permission under the `permissions` section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/acevedod1974/Lechugas/pull/6?shareId=85fcee52-7be2-41a4-a853-aab9020ddbec).